### PR TITLE
fix(#22): closes #22 with fixes on hardcoded values in getY

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Beta
+
+> This library is in beta. It's not ready for production.
+
 # SolStat
 
 SolStat is a Math library written in solidity for statistical function approximations. The library is composed of two core libraries; Gaussian.sol, and Invariant.sol. We will go over each of these libraries and their testing suites. We at Primitive use these libraries to support development with RMM-01s unique trading function, which utilizes the cumulative distribution function (CDF) of the normal distribution denoted by the greek capital letter Phi($\Phi$) in the literature [1,2]. You may recognize the normal or Gaussian distribution as the bell curve. This distribution is significant in modeling real-valued random numbers of unknown distributions. Within the RMM-01 trading function and options pricing, the CDF is used to model random price movement of a Markov process. Since price paths are commonly modeled with markovian proccesses, we believe that the greater community will find value in this library.
@@ -63,7 +67,7 @@ ierfc(2) = - infinity
 
 `Invariant.sol` is a contract used to compute the invariant of the RMM-01 trading function such that we compute $y$ in $y = K\Phi(\Phi^{⁻¹}(1-x) - \sigma\sqrt(\tau)) + k$. Notice how we need to compute the normal CDF of a quantity. For a more detailed perspective on the trading function, please see the whitepaper. This is an example of how we have used this library for our research, development, and testing of RMM-01. The function reverts if $x$ is greater than one and simplifies to $K(1+x) + k$ when $\tau$ is zero (at expiry). The function takes in five parameters
 `R_x`: The reserves of token $x$ per unit of liquidity, always within the bounds of $[0,1]$.
-`strk`: The strike price of the pool.
+`stk`: The strike price of the pool.
 `vol`: the implied volatility of the pool denoted by the lowercase greek letter sigma in finance literature.
 `tau`: The time until the pool expires. Once expired, there can be no swaps.
 `inv`: The current invariant given `R_x`.

--- a/src/Invariant.sol
+++ b/src/Invariant.sol
@@ -73,7 +73,7 @@ library Invariant {
      * Reverts if `R_x` is greater than one. Units are a fixed point number with 18 decimals.
      *
      * We handle some special cases, try this:
-     * `normalcdlower(normalicdlower(1) - 0.1)` in https://keisan.casio.com/calculator
+     * `normalcd(normalicd(1) - 0.1)` in https://keisan.casio.com/calculator
      * Gaussian.sol reverts for `ppf(1)` and `ppf(0)`, so we handle those cases.
      *
      * @param R_x Quantity of token reserve `x` within the bounds of [0, 1].
@@ -94,8 +94,8 @@ library Invariant {
         int256 inv
     ) internal pure returns (uint256 R_y) {
         if (R_x > WAD) revert OOB(); // Negative input for `ppf` is invalid.
-        if (R_x == WAD) return uint256(int256(stk) + inv); // For `ppf(0)` case, because 1 - R_x == 0, and `y = K * 1 + k` simplifies to `y = K + k`
-        if (R_x == 0) return uint256(inv); // For `ppf(1)` case, because 1 - 0 == 1, and `y = K * 0 + k` simplifies to `y = k`.
+        if (R_x == WAD) return uint256(inv); // For `ppf(0)` case, because 1 - 1 == 0, cdf(ppf(0)) == 0, and `y = K * 0 + k` simplifies to `y = k`.
+        if (R_x == 0) return uint256(int256(stk) + inv); // For `ppf(1)` case, because 1 - 0 == 1, cdf(ppf(1)) == 1, and `y = K * 1 + k` simplifies to `y = K + k`.
         if (tau != 0) {
             // Short circuits because tau != 0 is more likely.
             uint256 sec;

--- a/src/reference/ReferenceInvariant.sol
+++ b/src/reference/ReferenceInvariant.sol
@@ -26,8 +26,8 @@ library Invariant {
         int256 inv
     ) internal pure returns (uint256 R_y) {
         if (R_x > WAD) revert OOB(); // Negative input for `ppf` is invalid.
-        if (R_x == WAD) return uint256(int256(stk) + inv); // For `ppf(0)` case, because 1 - R_x == 0, and `y = K * 1 + k` simplifies to `y = K + k`
-        if (R_x == 0) return uint256(inv); // For `ppf(1)` case, because 1 - 0 == 1, and `y = K * 0 + k` simplifies to `y = k`.
+        if (R_x == WAD) return uint256(inv); // For `ppf(0)` case, because 1 - 1 == 0, cdf(ppf(0)) == 0, and `y = K * 0 + k` simplifies to `y = k`.
+        if (R_x == 0) return uint256(int256(stk) + inv); // For `ppf(1)` case, because 1 - 0 == 1, cdf(ppf(1)) == 1, and `y = K * 1 + k` simplifies to `y = K + k`.
         if (tau != 0) {
             // short circuit
             uint256 sec = tau.divWadDown(uint256(YEAR));

--- a/src/test/Invariant.t.sol
+++ b/src/test/Invariant.t.sol
@@ -521,4 +521,26 @@ contract TestInvariant is Test {
         }
         emit log_int(k);
     }
+
+    function test_getY_upper_bound_returns_zero() public {
+        HelperInvariant.Args memory args = HelperInvariant.Args({
+            x: Invariant.WAD,
+            K: 10e18,
+            o: 1e4,
+            t: 365 days
+        });
+        uint256 actual = Invariant.getY(args.x, args.K, args.o, args.t, 0);
+        assertEq(actual, 0, "not-zero");
+    }
+
+    function test_getY_lower_bound_returns_strike() public {
+        HelperInvariant.Args memory args = HelperInvariant.Args({
+            x: 0,
+            K: 10e18,
+            o: 1e4,
+            t: 365 days
+        });
+        uint256 actual = Invariant.getY(args.x, args.K, args.o, args.t, 0);
+        assertEq(actual, args.K, "not-strike");
+    }
 }


### PR DESCRIPTION
## Feat
- Updates the `getY` function to return `inv` when `R_x` argument is equal to 1e18.
- Updates the `getY` function to return `K + inv` when `R_x` argument is equal to 0.
- Adds two unit tests to test both cases.
- Updates readme with a beta version, non-production ready, warning.