### PR TITLE
allow for latest compiler

### DIFF
--- a/src/test/Cdf.t.sol
+++ b/src/test/Cdf.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.13;
+pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 

--- a/src/test/DifferentialTests.t.sol
+++ b/src/test/DifferentialTests.t.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.8.13;
+pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 

--- a/src/test/Erfc.t.sol
+++ b/src/test/Erfc.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.13;
+pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 

--- a/src/test/Gaussian.t.sol
+++ b/src/test/Gaussian.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.13;
+pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 

--- a/src/test/HelperInvariant.sol
+++ b/src/test/HelperInvariant.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.13;
+pragma solidity ^0.8.13;
 
 import "../Invariant.sol";
 

--- a/src/test/Ierfc.t.sol
+++ b/src/test/Ierfc.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.13;
+pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 

--- a/src/test/Invariant.t.sol
+++ b/src/test/Invariant.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.13;
+pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 

--- a/src/test/Pdf.t.sol
+++ b/src/test/Pdf.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.13;
+pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 

--- a/src/test/Ppf.t.sol
+++ b/src/test/Ppf.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.13;
+pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
 


### PR DESCRIPTION
This will allow the contracts to compile with the latest compiler version which was showing up in generating bindings for submodules